### PR TITLE
Fixes an invalid prop-type in the SearchBox component

### DIFF
--- a/src/SearchBox/index.jsx
+++ b/src/SearchBox/index.jsx
@@ -75,7 +75,7 @@ SearchBox.propTypes = {
     className: PropTypes.string,
     onSearch: PropTypes.func.isRequired,
     placeholder: PropTypes.string,
-    inputDisabled: PropTypes.boolean
+    inputDisabled: PropTypes.bool
 };
 
 SearchBox.defaultProps = {


### PR DESCRIPTION
The inputDisabled was declared as PropTypes.boolean which does not exist, it should be PropTypes.bool

Closes #175 