### PR TITLE
Updates react-portal-tooltip to v2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "react-height": "^3.0.0",
     "react-modal": "^3.5.1",
     "react-motion": "^0.5.2",
-    "react-portal-tooltip": "^2.4.0",
+    "react-portal-tooltip": "^2.4.2",
     "react-scrollbar": "^0.5.4",
     "react-slider": "0.11.2",
     "react-tabs": "2.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6903,9 +6903,10 @@ react-motion@^0.5.2:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react-portal-tooltip@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/react-portal-tooltip/-/react-portal-tooltip-2.4.0.tgz#0f2d558d9eb20ef5ab344c87572e63e7c373b229"
+react-portal-tooltip@^2.4.2:
+  version "2.4.2"
+  resolved "https://www.myget.org/F/dnn-software-public/npm/react-portal-tooltip/-/react-portal-tooltip-2.4.2.tgz#228595a8e02eccc4800457a6f8fde799603acc35"
+  integrity sha1-IoWVqOAuzMSABFem+P3nmWA6zDU=
 
 react-scrollbar@^0.5.4:
   version "0.5.4"


### PR DESCRIPTION
Fixes the tooltip usage with info bug, makes the Security module work and probably others too that had the same bug.

Replaces #183 

Closes #182 