### PR TITLE
Fixes display issue with comboboxes in PermissionGrid compoenent

### DIFF
--- a/src/PermissionGrid/Suggestion/style.less
+++ b/src/PermissionGrid/Suggestion/style.less
@@ -22,7 +22,9 @@
             border-radius: 0;
             box-shadow: none;
             background: transparent;
-
+            .rw-select{
+                display: none;
+            }
             &.rw-state-focus, &.rw-state-focus:hover{
                 border: none;
                 outline: none;
@@ -49,6 +51,10 @@
             :-ms-input-placeholder {
                 /* Internet Explorer 10-11 */
                 color: @alto;
+            }
+            .rw-widget-container{
+                background-color: transparent;
+                border: none;
             }
             input {
                 -webkit-box-shadow: none;


### PR DESCRIPTION
The compoenent used for comboboxes has changed to a newer version and the css to override it was no longer effective in the permissions grid, this PR fixed that.

Closes #171 