### PR TITLE
Fixes the incorrect border in PagePicker

### DIFF
--- a/src/PagePicker/style.less
+++ b/src/PagePicker/style.less
@@ -49,7 +49,7 @@
         -webkit-box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.2);
         -moz-box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.2);
         box-shadow: 0px 0px 20px 0px rgba(0, 0, 0, 0.2);
-        border: 1px solid transparent;
+        border: 0px;
     }
     .page-picker-content {
         >div {


### PR DESCRIPTION
Originally the css was set on the collapsible area to start with a 1px transparent border which made the content be 2px high, thus showing 2px of white background hiding the textbox underlaying border. This removes the border completelly when not expanded in order to prevent that issue while maintaining correct animation of the collapsible area.

Closes #189 