### PR TITLE
DNN-22051 Site Setting - behavior - Cancel  is not working, V2

### DIFF
--- a/src/PagePicker/index.jsx
+++ b/src/PagePicker/index.jsx
@@ -126,6 +126,7 @@ class PagePicker extends Component {
             portalTabs[0].Processed = true;
             portalTabs[0].ParentTabId = undefined;
             portalTabs[0].ChildTabs = portalTabs[0].ChildTabs.map(tab => {
+                tab.TabId = tab.TabId !== null ? parseInt(tab.TabId) : -1;
                 tab.ChildTabs = tab.ChildTabs !== null ? tab.ChildTabs : [];
                 return tab;
             });


### PR DESCRIPTION
This is a replacement PR due to not being able to fix the merge conflict on #151 

Closes #152 

Fixes an issue where clicking cancel in some modules does not reset the dropdowns to their default values due to the value being a string instead of a number in some situations. I have tested #151 and it already got approved by 2 persons, could just not merge it due to the affected file being renamed before it got merged, so found no other way to fix that do a new PR.