### PR TITLE
Fixed deprecated methods in React 16, added some stories

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -16,7 +16,7 @@ module.exports = {
         "react": {
             "createClass": "createReactClass",
             "pragma": "React",  
-            "version": "15.0",
+            "version": "16.4.2",
             "flowVersion": "0.53"
           },
           "propWrapperFunctions": [ "forbidExtraProps" ]
@@ -60,6 +60,7 @@ module.exports = {
         "import/no-unresolved": 2,
         "import/named": 2,
         "import/default": 2,
-        "filenames/match-exported": 2
+        "filenames/match-exported": 2,
+        "react/no-deprecated": "error"
     }
 };

--- a/src/Checkbox/checkbox.stories.js
+++ b/src/Checkbox/checkbox.stories.js
@@ -6,3 +6,7 @@ import Checkbox from "./index";
 storiesOf("Checkbox", module).add("with text", () => (
   <Checkbox value={false} onChange={action("changed")} label="Hello Checkbox" />
 ));
+
+storiesOf("Checkbox", module).add("already checked", () => (
+  <Checkbox value={true} onChange={action("changed")} label="I should be pre-checked" />
+));

--- a/src/Checkbox/index.jsx
+++ b/src/Checkbox/index.jsx
@@ -5,23 +5,18 @@ import "./style.less";
 
 export default class Checkbox extends Component {
 
-    constructor() {
-        super();
-
+    constructor(props) {
+        super(props);
+        this.state = { checked: props.value ? props.value : false };
         this.id = "checkbox-" + Math.random() + Date.now();
     }
 
-    componentWillMount() {
-        const {props} = this;
-        this.setState({
-            checked: props.value
-        });
-    }
-
-    componentWillReceiveProps(props) {
-        this.setState({
-            checked: props.value
-        });
+    componentDidUpdate(prevProps) {
+        if (this.props.value !== prevProps.value) {
+            this.setState({
+                checked: props.value
+            });
+        }
     }
 
     onClick() {

--- a/src/Collapsible/collapsible.stories.js
+++ b/src/Collapsible/collapsible.stories.js
@@ -1,31 +1,52 @@
-import React from "react";
+import React, { Component } from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import Collapsible from "./index";
+import InputGroup from "../InputGroup";
+import SingleLineInputWithError from "../SingleLineInputWithError";
+import MultiLineInputWithError from "../MultiLineInputWithError";
+import Button from "../Button";
+
+class MyCollapsible extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { opened: true };
+  }
+
+  render (){
+    return (
+      <div>
+        <Collapsible isOpened={this.state.opened} autoScroll={true} scrollDelay={10}>
+          <div>
+            <p className="add-term-title">Add Term</p>
+            <InputGroup>
+              <SingleLineInputWithError
+                inputId={"create-term-name"}
+                withLabel={true}
+                label="Required Term *"
+                value="Term Value"
+                onChange={action("changed")}
+                errorMessage="Error"
+              />
+            </InputGroup>
+            <InputGroup>
+              <MultiLineInputWithError
+                inputId={"create-term-description"}
+                withLabel={true}
+                label="Description"
+                value="Long descritpion here"
+                onChange={action("changed")}
+              />
+            </InputGroup>
+          </div>
+        </Collapsible>
+        <Button onClick={() => this.setState({opened: true})}>Open</Button>
+        <Button onClick={() => this.setState({opened: false})}>Close</Button>
+      </div>
+    );
+  }
+}
 
 storiesOf("Collapsible", module).add("with text", () => (
-  <Collapsible isOpened={true} autoScroll={true} scrollDelay={10}>
-    <div>
-      <p className="add-term-title">Add Term</p>
-      <InputGroup>
-        <SingleLineInputWithError
-          inputId={"create-term-name"}
-          withLabel={true}
-          label="Required Term *"
-          value="Term Value"
-          onChange={action("changed")}
-          errorMessage="Error"
-        />
-      </InputGroup>
-      <InputGroup>
-        <MultiLineInputWithError
-          inputId={"create-term-description"}
-          withLabel={true}
-          label="Description"
-          value="Long descritpion here"
-          onChange={action("changed")}
-        />
-      </InputGroup>
-    </div>
-  </Collapsible>
+  <MyCollapsible />
 ));

--- a/src/CollapsibleRow/index.jsx
+++ b/src/CollapsibleRow/index.jsx
@@ -5,8 +5,9 @@ import Button from "../Button";
 import "./style.less";
 
 export default class CollapsibleRow extends Component {
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
+        this.state = { collapsed: props.collapsed ? props.collapsed : true };
         this.handleClick = this.handleClick.bind(this);
     }
 
@@ -18,16 +19,12 @@ export default class CollapsibleRow extends Component {
         }
     }
 
-    componentWillMount() {
-        this.setState({ collapsed: this.props.collapsed });
-    }
-
-    componentWillReceiveProps(newProps) {
-        if (newProps.collapsed !== this.props.collapsed) {
-            this.setState({ collapsed: newProps.collapsed });
+    componentDidUpdate(prevProps) {
+        if (this.props.collapsed !== prevProps.collapsed) {
+            this.setState({ collapsed: this.props.collapsed });
         }
     }
-
+    
     componentWillUnmount() {
         document.removeEventListener("click", this.handleClick);
         this._isMounted = false;

--- a/src/ContentLoadWrapper/contentloadwrapper.stories.js
+++ b/src/ContentLoadWrapper/contentloadwrapper.stories.js
@@ -1,7 +1,39 @@
-import React from "react";
+import React, { Component } from "react";
 import { storiesOf } from "@storybook/react";
 import ContentLoadWrapper from "./index";
 import { TableEmptyState } from "../SvgIcons";
+
+class MyContentLoadWrapper extends Component{
+  constructor(){
+    super();
+    this.state = { loaded: false };    
+  }
+
+  componentDidMount(){
+    setTimeout(function(){
+      this.setState({ loaded: true });
+    }.bind(this), 2000);
+  }
+
+  render(){
+    return (
+      <ContentLoadWrapper
+        loadComplete={this.state.loaded}
+        svgSkeleton={<div dangerouslySetInnerHTML={{ __html: TableEmptyState }} />}
+      >
+        <div>
+          <div className="auditCheckItems">
+            <ul>
+              <li>Item 1</li>
+              <li>Item 2</li>
+              <li>Item 3</li>
+            </ul>
+          </div>
+        </div>
+      </ContentLoadWrapper>  
+    );
+  }
+}
 
 storiesOf("ContentLoadWrapper", module).add("with loading", () => (
   <ContentLoadWrapper
@@ -40,4 +72,8 @@ storiesOf("ContentLoadWrapper", module).add("with content", () => (
       </div>
     </div>
   </ContentLoadWrapper>
+));
+
+storiesOf("ContentLoadWrapper", module).add("loaded after 2 seconds", () => (
+  <MyContentLoadWrapper />
 ));

--- a/src/ContentLoadWrapper/index.jsx
+++ b/src/ContentLoadWrapper/index.jsx
@@ -23,32 +23,37 @@ export default class ContentLoadWrapper extends Component {
         this._isMounted = false;
     }
 
-    componentWillReceiveProps(props) {
-        if (props.loadComplete) {
-            clearTimeout(this.setTimeout);
-            if (this._isMounted) {
-                this.setState({ percent: 100 }, () => {
-                });
-            }
-            setTimeout(() => {
-                if (typeof props.onCompleteCallback === "function") {
-                    props.onCompleteCallback();
+    componentDidUpdate(prevProps) {
+        let { props } = this;
+        if (props.loadComplete !== prevProps.loadComplete) {
+            if (props.loadComplete) {
+                clearTimeout(this.setTimeout);
+                if (this._isMounted) {
+                    this.setState({ percent: 100 }, () => {
+                    });
                 }
-            }, 300);
-        }
-        if (props.loadError) {
-            clearTimeout(this.setTimeout);
-            if (this._isMounted) {
-                this.setState({ percent: 100 }, () => {
-                });
+                setTimeout(() => {
+                    if (typeof props.onCompleteCallback === "function") {
+                        props.onCompleteCallback();
+                    }
+                }, 300);
             }
-            setTimeout(() => {
-                if (typeof props.onErrorCallback === "function") {
-                    props.onErrorCallback();
-                }
-            }, 300);
         }
-    }
+        if (props.loadError !== prevProps.loadError) {
+            if (props.loadError) {
+                clearTimeout(this.setTimeout);
+                if (this._isMounted) {
+                    this.setState({ percent: 100 }, () => {
+                    });
+                }
+                setTimeout(() => {
+                    if (typeof props.onErrorCallback === "function") {
+                        props.onErrorCallback();
+                    }
+                }, 300);
+            }
+        }
+    }    
 
     increase() {
         let {percent} = this.state;

--- a/src/DatePicker/DateInput.jsx
+++ b/src/DatePicker/DateInput.jsx
@@ -19,17 +19,19 @@ export default class DateInput extends Component {
 
     }
 
-    componentWillReceiveProps(props) {
-        const month = props.date ? this.addZero(props.date.getMonth() + 1) : "";
-        const day = props.date ? this.addZero(props.date.getDate()) : "";
-        const year = props.date ? props.date.getFullYear() : "";
-        const hours = props.date ? this.getHour(props.date.getHours()) : "";
-        const minutes = props.date ? this.addZero(props.date.getMinutes()) : "";
-        const period = props.date ? this.getPeriod(props.date.getHours()) : this.getPeriod(false);
+    componentDidUpdate(prevProps) {
+        let { props } = this;
+        if (props.date !== prevProps.date) {
+            const month = props.date ? this.addZero(props.date.getMonth() + 1) : "";
+            const day = props.date ? this.addZero(props.date.getDate()) : "";
+            const year = props.date ? props.date.getFullYear() : "";
+            const hours = props.date ? this.getHour(props.date.getHours()) : "";
+            const minutes = props.date ? this.addZero(props.date.getMinutes()) : "";
+            const period = props.date ? this.getPeriod(props.date.getHours()) : this.getPeriod(false);
 
-        this.setState({ month, day, year, hours, minutes, period });
+            this.setState({ month, day, year, hours, minutes, period });
+        }
     }
-
 
     setMonth() {
         let {month} = this.state;
@@ -210,7 +212,7 @@ export default class DateInput extends Component {
                     <span>{this.state.period}</span>
                 </div>
             </div>}
-        </div >;
+        </div>;
     }
 }
 

--- a/src/Dropdown/dropdown.stories.js
+++ b/src/Dropdown/dropdown.stories.js
@@ -1,15 +1,33 @@
-import React from "react";
+import React, { Component } from "react";
 import { storiesOf } from "@storybook/react";
 import Dropdown from "./index";
 
+class MyDropdown extends Component{
+    constructor(){
+        super();
+        this.state = { option: {} }
+    }
+
+    handleSelect(option){
+        this.setState( { option: option });
+    }
+
+    render(){
+        return (
+            <Dropdown
+                label="Test"
+                options={[
+                    { label: "Opt 1", value: 1 },
+                    { label: "Opt 2", value: 2 },
+                    { label: "Opt 3", value: 3 }
+                ]}
+                value={this.state.option.value}
+                onSelect={this.handleSelect.bind(this)}
+            />
+        );
+    }
+}
+
 storiesOf("Dropdown", module).add("with content", () => (
-    <Dropdown
-        label="Test"
-        options={[
-            { label: "Opt 1", value: 1 },
-            { label: "Opt 2", value: 2 },
-            { label: "Opt 3", value: 3 }
-        ]}
-        selectedIndex={1}
-    />
+    <MyDropdown />
 ));

--- a/src/Dropdown/index.jsx
+++ b/src/Dropdown/index.jsx
@@ -44,6 +44,12 @@ class Dropdown extends Component {
                 dropDownOpen: false
             });
         }
+        if (props.options && props.options.length > 0) {
+            let fixedHeight = DNN_DROPDOWN_MINHEIGHT;
+            this.setState({
+                fixedHeight
+            });
+        }
     }
 
     getDropdownHeight() {
@@ -52,25 +58,18 @@ class Dropdown extends Component {
         return this.dropDownListElement ? Math.min(this.dropDownListElement.offsetHeight, maxHeight) + 20 : 0;
     }
 
-    componentWillMount() {
-        const {props} = this;
-        if (props.options && props.options.length > 0) {
-            let fixedHeight = DNN_DROPDOWN_MINHEIGHT;
-            this.setState({
-                fixedHeight
-            });
-        }
-    }
-
-    componentWillReceiveProps(props) {
-        if (props.options && props.options.length > 0) {
-            let fixedHeight = DNN_DROPDOWN_MINHEIGHT;
-            this.setState({
-                fixedHeight
-            });
+    componentDidUpdate(prevProps) {
+        const { props } = this;
+        if (props.options !== prevProps.options) {
+            if (props.options && props.options.length > 0) {
+                let fixedHeight = DNN_DROPDOWN_MINHEIGHT;
+                this.setState({
+                    fixedHeight
+                });
+            }
         }
 
-        if (props.isDropDownOpen !== this.props.isDropDownOpen) {
+        if (props.isDropDownOpen !== prevProps.isDropDownOpen) {
             this.setState({dropDownOpen: !props.isDropDownOpen}, () => this.toggleDropdown(true));
         }
     }

--- a/src/EditableField/index.jsx
+++ b/src/EditableField/index.jsx
@@ -6,19 +6,16 @@ import { EditIcon } from "../SvgIcons";
 import "./style.less";
 
 class EditableField extends Component {
-    constructor() {
-        super();
-        this.uniqueId = "editableField-" + (Date.now() * Math.random());
-    }
-
-    componentWillMount() {
-        const { props } = this;
-        this.setState({
+    constructor(props) {
+        super(props);
+        this.state = {
             editMode: false,
             value: props.value,
             error: false
-        });
+        };
+        this.uniqueId = "editableField-" + (Date.now() * Math.random());
     }
+    
     toggleEditMode() {
         this.setState({
             editMode: !this.state.editMode

--- a/src/FileUpload/Browse/Folders.jsx
+++ b/src/FileUpload/Browse/Folders.jsx
@@ -11,16 +11,18 @@ export default class Folders extends Component {
         };
     }
 
-    componentWillReceiveProps(props) {
+    componentDidUpdate(prevProps) {
+        const { props } = this;
         if (!props.folders || !props.folders.children || !props.folders.children[0] || !props.folders.children[0].data || !props.folders.children[0].data.key) {
             return;
         }
         const rootKey = props.folders.children[0].data.key;
         let {openFolders} = this.state;
         openFolders.push(rootKey);
-        this.setState({ openFolders });
+        if (this.state.openFolders !== openFolders) {
+            this.setState({ openFolders });
+        }
     }
-
 
     toggleFolder(key) {
         let {openFolders} = this.state;

--- a/src/FileUpload/Browse/index.jsx
+++ b/src/FileUpload/Browse/index.jsx
@@ -57,8 +57,8 @@ export default class Browse extends Component {
         return this.props.onSave(this.state.selectedFolder, this.state.selectedFile);
     }
 
-    componentWillReceiveProps(nextProps) {        
-        if (nextProps.portalId !== this.props.portalId) {
+    componentDidUpdate(prevProps) {
+        if (this.props.portalId !== prevProps.portalId) {
             this.getFolders();
         }
     }

--- a/src/FileUpload/UploadBar.jsx
+++ b/src/FileUpload/UploadBar.jsx
@@ -19,9 +19,10 @@ export default class UploadBar extends Component {
     componentDidMount() {
         setTimeout(this.increase.bind(this), 100);
     }
-
-    componentWillReceiveProps(props) {
-        if (props.uploadComplete) {
+    
+    componentDidUpdate(prevProps) {
+        const { props } = this;
+        if (props.uploadComplete && props.uploadComplete !== prevProps.uploadComplete) {
             clearTimeout(this.setTimeout);
             this.setState({percent: 100});
         }

--- a/src/FileUpload/index.jsx
+++ b/src/FileUpload/index.jsx
@@ -58,26 +58,27 @@ export default class FileUpload extends Component {
         });
     }
 
-    componentWillMount() {
+    componentDidMount() {
         const file = this.props.selectedFile;
         if (file) {
             this.updateStateAndReloadImage(file);
         }
     }
 
-    componentWillReceiveProps(nextProps) {
-        if (!nextProps.selectedFile) {
+    componentDidUpdate(prevProps) {
+        const { props } = this;
+        if (!props.selectedFile && props.selectedFile !== prevProps.selectedFile) {
             this.setState({ fileExist: null, selectedFile: null, selectedFolder: null }, () => {});
             return;
         }
-        if (nextProps.selectedFile && this.state.selectedFile)
+        if (props.selectedFile && props.selectedFile !== prevProps.selectedFile && this.state.selectedFile)
         {
-            if (nextProps.selectedFile.fileId !== (this.state.selectedFile.fileId || + this.state.selectedFile.key)) {
-                const file = nextProps.selectedFile;
+            if (props.selectedFile.fileId !== (this.state.selectedFile.fileId || + this.state.selectedFile.key)) {
+                const file = props.selectedFile;
                 this.updateStateAndReloadImage(file);
             }
         }
-        if (nextProps.portalId !== this.props.portalId) {         
+        if (props.portalId !== prevProps.portalId) {         
             this.setState({ showFolderPicker: false });
         }
     }

--- a/src/FolderPicker/Folders.jsx
+++ b/src/FolderPicker/Folders.jsx
@@ -13,15 +13,18 @@ export default class Folders extends Component {
         };
     }
 
-    componentWillReceiveProps(props) {
-        if (!props.folders || !props.folders.children || !props.folders.children[0] || 
-            !props.folders.children[0].data || !props.folders.children[0].data.key) {
-            return;
+    componentDidUpdate(prevProps) {
+        const { props } = this;
+        if (props.folders !== prevProps.folders) {
+            if (!props.folders || !props.folders.children || !props.folders.children[0] || 
+                !props.folders.children[0].data || !props.folders.children[0].data.key) {
+                return;
+            }
+            const rootKey = props.folders.children[0].data.key;
+            const {openFolders} = this.state;
+            openFolders.push(rootKey);
+            this.setState({ openFolders });
         }
-        const rootKey = props.folders.children[0].data.key;
-        const {openFolders} = this.state;
-        openFolders.push(rootKey);
-        this.setState({ openFolders });
     }
 
 

--- a/src/PagePicker/index.jsx
+++ b/src/PagePicker/index.jsx
@@ -33,7 +33,8 @@ class PagePicker extends Component {
         this.dnnPagePickerRef = React.createRef();
         this.pagePickerContent = React.createRef();
     }
-    componentWillMount() {
+
+    UNSAFE_componentWillMount() {
         this._isMounted = false;
         if (!this.props.IsMultiSelect) {
             this.setDefaultPage(this.props);
@@ -46,7 +47,7 @@ class PagePicker extends Component {
         });
     }
 
-    componentWillReceiveProps(newProps) {
+    UNSAFE_componentWillReceiveProps(newProps) {
         //reload if any query param changed
         const {props} = this;
         if (props.PortalTabsParameters.portalId !== newProps.PortalTabsParameters.portalId ||

--- a/src/Pager/index.jsx
+++ b/src/Pager/index.jsx
@@ -18,12 +18,18 @@ class Pager extends Component {
             totalPages: 0,
             startIndex: 0,
             endIndex: props.numericCounters !== undefined ? props.numericCounters : 0
-        };
-        this.calculateTotalPages(props);
+        };        
     }
-    componentWillReceiveProps(newProps) {
-        this.calculateTotalPages(newProps);
+
+    componentDidMount() {
+        this.calculateTotalPages(this.props);
     }
+
+    componentDidUpdate(prevProps) {
+        if (prevProps.totalRecords !== this.props.totalRecords)
+            this.calculateTotalPages(this.props);
+    }
+    
     formatCommaSeparate(number) {
         let numbersSeparatorByLocale = this.getNumbersSeparatorByLocale();
         while (/(\d+)(\d{3})/.test(number.toString())) {
@@ -181,14 +187,14 @@ class Pager extends Component {
             for (let i = startIndex; i < endIndex; i++) {
                 let step = i + 1;
                 if (i !== currentPage) {
-                    pagingBoxes = pagingBoxes.concat(<li className="pages do-not-close" onClick={this.onPageChanged.bind(this, i)}>{this.formatCommaSeparate(step)}</li>);
+                    pagingBoxes = pagingBoxes.concat(<li key={"li" + i} className="pages do-not-close" onClick={this.onPageChanged.bind(this, i)}>{this.formatCommaSeparate(step)}</li>);
                 } else {
-                    pagingBoxes = pagingBoxes.concat(<li className="pages current do-not-close">{this.formatCommaSeparate(i + 1)}</li>);
+                    pagingBoxes = pagingBoxes.concat(<li key={"li" + i} className="pages current do-not-close">{this.formatCommaSeparate(i + 1)}</li>);
                 }
             }
         }
         else if (this.props.numericCounters === 1) {
-            pagingBoxes = pagingBoxes.concat(<li className="pages current do-not-close">{this.formatCommaSeparate(currentPage + 1)}</li>);
+            pagingBoxes = pagingBoxes.concat(<li key="li-single" className="pages current do-not-close">{this.formatCommaSeparate(currentPage + 1)}</li>);
         }
         return pagingBoxes;
     }

--- a/src/Pager/pager.stories.js
+++ b/src/Pager/pager.stories.js
@@ -9,3 +9,11 @@ storiesOf("Pager", module).add("with content", () => (
         onPageChanged={action("changed")}
     />
 ));
+
+storiesOf("Pager", module).add("with 5 numeric counters", () => (
+    <Pager
+        totalRecords={100}
+        onPageChanged={action("changed")}
+        numericCounters={5}
+    />
+));

--- a/src/PermissionGrid/Grid.jsx
+++ b/src/PermissionGrid/Grid.jsx
@@ -1,8 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import GridCell from "../GridCell";
-import Button from "../Button";
-import Label from "../Label";
 import GridCaption from "./GridCaption";
 import GridHeader from "./GridHeader";
 import GridRow from "./GridRow";
@@ -13,10 +11,6 @@ class Grid extends Component {
 
         this.state = {
         };
-    }
-
-    componentWillMount() {
-        const {props, state} = this;
     }
 
     onPermissionChange(permission) {

--- a/src/PermissionGrid/GridHeader.jsx
+++ b/src/PermissionGrid/GridHeader.jsx
@@ -10,10 +10,6 @@ class GridHeader extends Component {
         };
     }
 
-    componentWillMount() {
-        const {props, state} = this;
-    }
-
     getLocaliztion(key) {
         let localized = this.props.localization[key.replace(" ", "")];
         return localized || key;

--- a/src/PermissionGrid/RoleGroupFilter/index.jsx
+++ b/src/PermissionGrid/RoleGroupFilter/index.jsx
@@ -23,9 +23,7 @@ class RoleGroupFilter extends Component {
         this.groupsDropdown = React.createRef();
     }
 
-    componentWillMount() {
-        const { props, state } = this;
-
+    componentDidMount() {
         this.getRoleGroups();
     }
 

--- a/src/PermissionGrid/Suggestion/index.jsx
+++ b/src/PermissionGrid/Suggestion/index.jsx
@@ -18,13 +18,15 @@ class Suggestion extends Component {
         this.debounceGetSuggestions = debounce(500, this.debounceGetSuggestions);
     }
 
-    componentWillReceiveProps() {
-        this.setState({ selectedValue: { value: -1, label: "" }, suggestions: [] });
+    componentDidUpdate(prevProps) {
+        if (this.props.options !== prevProps.options) {
+            this.setState({ selectedValue: { value: -1, label: "" }, suggestions: [] });
+        }
     }
 
     componentDidMount() {
-        if (this.comboBoxDom.childNodes !== undefined){
-                this.comboBoxDom.childNodes[1].setAttribute("aria-label", "Suggestion");
+        if (this.comboBoxDom.childNodes !== undefined) {
+            this.comboBoxDom.childNodes[1].setAttribute("aria-label", "Suggestion");
         }
     }
 

--- a/src/PermissionGrid/index.jsx
+++ b/src/PermissionGrid/index.jsx
@@ -34,16 +34,14 @@ class PermissionGrid extends Component {
         };
     }
 
-    componentWillMount() {
-        const {props, state} = this;
-    }
-
-    componentWillReceiveProps(newProps) {
-        this.setState({
-            definitions: newProps.permissions.permissionDefinitions,
-            rolePermissions: newProps.permissions.rolePermissions,
-            userPermissions: newProps.permissions.userPermissions
-        });
+    componentDidUpdate(prevProps) {
+        if (this.props.permissions !== prevProps.permissions) {
+            this.setState({
+                definitions: this.props.permissions.permissionDefinitions,
+                rolePermissions: this.props.permissions.rolePermissions,
+                userPermissions: this.props.permissions.userPermissions
+            });
+        }
     }
 
     localize(key) {

--- a/src/RadioButtons/index.jsx
+++ b/src/RadioButtons/index.jsx
@@ -4,22 +4,28 @@ import Tooltip from "../Tooltip";
 import "./style.less";
 
 class RadioButtons extends Component {
-    componentWillMount() {
-        const {props} = this;
-        this.setState({
+    
+    constructor(props) {
+        super(props);
+        this.state = {
             value: props.value
-        });
+        };
+    }    
+
+    componentDidUpdate(prevProp) {
+        if (this.props.value !== prevProp.value) {
+            this.setState({
+                value: this.props.value
+            });
+        }
     }
-    componentWillReceiveProps(prop) {
-        this.setState({
-            value: prop.value
-        });
-    }
+
     onChange(event) {
         const {props} = this;
         const value = event.target.value;
         props.onChange(value);
     }
+
     render() {
         const {props, state} = this;
         const tooltipMessages = props.tooltipMessage instanceof Array ? props.tooltipMessage : [props.tooltipMessage];

--- a/src/RadioButtons/radiobuttons.stories.js
+++ b/src/RadioButtons/radiobuttons.stories.js
@@ -1,15 +1,28 @@
-import React from "react";
+import React, { Component } from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import RadioButtons from "./index";
 
+class MyRadioButtons extends Component{
+  constructor(){
+    super();
+    this.state = { value: 1 };
+  }
+
+  render(){
+    return (
+      <RadioButtons
+        options={[
+          { value: "1", label: "Value 1" },
+          { value: "2", label: "Value 2" }
+        ]}
+        onChange={(value) => this.setState({value:value})}
+        value={this.state.value}
+      />
+    );
+  }
+}
+
 storiesOf("RadioButtons", module).add("with content", () => (
-  <RadioButtons
-    options={[
-      { value: "1", label: "Value 1" },
-      { value: "2", label: "Value 2" }
-    ]}
-    onChange={action("Change")}
-    value={"1"}
-  />
+  <MyRadioButtons />
 ));

--- a/src/SearchBox/index.jsx
+++ b/src/SearchBox/index.jsx
@@ -38,7 +38,7 @@ class SearchBox extends Component {
         };
     }
     
-    componentWillMount() {
+    UNSAFE_componentWillMount() {
         this.debouncedSearch = debounce(this.search, 1000);
     }
     

--- a/src/Sortable/Draggable.jsx
+++ b/src/Sortable/Draggable.jsx
@@ -10,6 +10,7 @@ export default (Component) => {
         constructor() {
             super();
             this.initialScrollY = 0;
+            this.node = React.createRef();
         }
 
         showGhostTargetOnClone(currentTarget) {            
@@ -117,7 +118,7 @@ export default (Component) => {
                 showGhostOnClone
             } = this.props;
             
-            interact(dragElement).ignoreFrom("input, *[contenteditable=true], .ignoreDraggable").draggable({
+            interact(dragElement).ignoreFrom("input, *[contenteditable=true], .ignoreDraggable").draggable({                
                 manualStart: cloneElementOnDrag,
                 onmove: (event) => {                            
                     this.moveTarget(event);
@@ -168,7 +169,7 @@ export default (Component) => {
                     // start a drag interaction targeting the clone
                     interaction.start({ name: "drag" }, event.interactable, clone);
                 }
-            }).on("dragstart", (event) => {
+            }).on("dragstart", (event) => {                
                 this.initialScrollY = window.scrollY;
                 if (typeof(onDragStart) === "function") {
                     onDragStart(self, event);

--- a/src/Sortable/Droppable.jsx
+++ b/src/Sortable/Droppable.jsx
@@ -6,6 +6,11 @@ export default (Component) => {
     
     class Droppable extends React.Component {
     
+        constructor() {
+            super();
+            this.node = React.createRef();
+        }
+
         raiseEvent(event, callback) {
             const dropZoneRect = event.dropzone._element.getBoundingClientRect();
             const elementRect = event.relatedTarget.getBoundingClientRect();            

--- a/src/Sortable/index.jsx
+++ b/src/Sortable/index.jsx
@@ -22,11 +22,13 @@ export default class Sortable extends Component {
         this.dnnSortableRef = React.createRef();
     }
 
-    componentWillReceiveProps(newProps) {
-        const items = newProps.items.map((item, index) => {
-            return { index, item, id: index };
-        });
-        this.setState({items});
+    componentDidUpdate(prevProps) {
+        if (this.props.items !== prevProps.items) {
+            const items = this.props.items.map((item, index) => {
+                return { index, item, id: index };
+            });
+            this.setState({items});
+        }
     }
 
     sortColumns(a, b) {
@@ -37,9 +39,7 @@ export default class Sortable extends Component {
         return 0;
     }
 
-    onDragStart(component, event) {
-        const itemElement = this.dnnSortableRef.querySelectorAll(`[data-dnn-sortable-id="${id}"]`)[0];
-
+    onDragStart(component, event) {                
         let dragging = {
             isDragging: true
         };

--- a/src/Switch/index.jsx
+++ b/src/Switch/index.jsx
@@ -14,10 +14,12 @@ class Switch extends Component {
         };
     }
 
-    componentWillReceiveProps(props) {
-        this.setState({
-            switchActive: props.value
-        });
+    componentDidUpdate(prevProps) {
+        if (this.props.value !== prevProps.value) {
+            this.setState({
+                switchActive: this.props.value
+            });
+        }
     }
 
     toggleStatus() {

--- a/src/Switch/switch.stories.js
+++ b/src/Switch/switch.stories.js
@@ -1,7 +1,28 @@
-import React from "react";
+import React, { Component } from "react";
 import { storiesOf } from "@storybook/react";
 import { action } from "@storybook/addon-actions";
 import Switch from "./index";
+
+class ControlledSwitch extends Component {
+  constructor(props){
+    super(props);
+    this.state = { value: props.value ? props.value : false}
+  }
+
+  render(){
+    return (
+      <Switch
+        labelHidden={false}
+        onText="On"
+        offText="Off"
+        label="Controlled Switch"
+        onChange={(value) => this.setState({ value: value })}
+        labelPlacement="left"
+        value={this.state.value}    
+      />
+    );
+  }
+}
 
 storiesOf("Switch", module).add("with off", () => (
   <Switch
@@ -24,4 +45,8 @@ storiesOf("Switch", module).add("with on", () => (
     labelPlacement="left"
     value={true}
   />
+));
+
+storiesOf("Switch", module).add("controlled switch", () => (
+  <ControlledSwitch />
 ));

--- a/src/Tooltip/index.jsx
+++ b/src/Tooltip/index.jsx
@@ -55,9 +55,13 @@ function getIconComponent(type) {
 
 class Tooltip extends Component {
 
-    componentWillMount() {
+    constructor() {
+        super();
         const id = uniqueId("tooltip-");
-        this.setState({id: id, active: false});
+        this.state = {
+            id: id, 
+            active: false
+        };
     }
 
     showTooltip() {

--- a/src/TreeControlInteractor/index.jsx
+++ b/src/TreeControlInteractor/index.jsx
@@ -17,10 +17,12 @@ export default class TreeControlInteractor extends Component {
         this.individuallyChecked = 1;
         this.unchecked = 0;
         this.scrollbar = {};
+        this.state = {
+            tabs: []
+        };
     }
 
-    componentWillMount() {
-        this.setState({ tabs: [] });
+    componentDidMount() {        
         this.init();
     }
 
@@ -28,7 +30,6 @@ export default class TreeControlInteractor extends Component {
         if (this.scrollbar.getClientWidth() > 200) {
             this.scrollbar.scrollToRight();
         }
-
     }
 
     init() {


### PR DESCRIPTION
Some lifecycle methods where not being called because they are deprecated in React 16 but eslint was validating the code for React 15 so there was no warnings or errors.

This pull request:
* updates eslint config to validate for the React version in use
* Replaces most of the deprecated methods by the correct new recommended way of doing things (everything I could test in the storybook)
* Replaces a few methods by their temporary UNSAFE_ version because there was no way to test quickly, this will work until React 17, but needs attention at some point
* Adds / Changes a couple stories to test better some components events

Closes #193 