### PR TITLE
Pager component is having js warnings after react upgrade

### DIFF
--- a/src/Pager/index.jsx
+++ b/src/Pager/index.jsx
@@ -241,44 +241,49 @@ class Pager extends Component {
     }
     render() {
         const { state, props } = this;
-        return (state.totalPages > 1 || (props.totalRecords >= 10 && state.totalPages === 1 && this.props.showPageSizeOptions)) &&
-            <div className="dnn-pager do-not-close" style={props.style}>
-                <div className="dnn-pager-summary-box">
-                    {this.getPageSummary()}
-                </div>
-                <div className="dnn-pager-control">
-                    <div className="dnn-pager-paging-box">
-                        <ul>
-                            {
-                                this.props.showStartEndButtons &&
-                                this.renderIcon(this.onPageChanged.bind(this, "<<"), ArrowEndLeftIcon, state.currentPage < 1)
-                            }
-                            {
-                                this.renderIcon(this.onPageChanged.bind(this, "<"), ArrowLeftIcon, state.currentPage < 1)
-                            }
-                            {this.getPagingBoxes()}
-                            {
-                                this.renderIcon(this.onPageChanged.bind(this, ">"), ArrowRightIcon, state.totalPages <= (state.currentPage + 1))
-                            }
-                            {
-                                this.props.showStartEndButtons &&
-                                this.renderIcon(this.onPageChanged.bind(this, ">>"), ArrowEndRightIcon, state.totalPages <= (state.currentPage + 1))
-                            }
-                        </ul>
+        if (state.totalPages > 1 || (props.totalRecords >= 10 && state.totalPages === 1 && this.props.showPageSizeOptions)) {
+            return (
+                <div className="dnn-pager do-not-close" style={props.style}>
+                    <div className="dnn-pager-summary-box">
+                        {this.getPageSummary()}
                     </div>
-                    {this.props.showPageInfo && !this.props.showPageSizeOptions &&
-                        <div className="dnn-pager-options-info-box">
-                            {this.format(this.props.pageInfoText, this.formatCommaSeparate(state.currentPage + 1), this.formatCommaSeparate(state.totalPages))}
+                    <div className="dnn-pager-control">
+                        <div className="dnn-pager-paging-box">
+                            <ul>
+                                {
+                                    this.props.showStartEndButtons &&
+                                    this.renderIcon(this.onPageChanged.bind(this, "<<"), ArrowEndLeftIcon, state.currentPage < 1)
+                                }
+                                {
+                                    this.renderIcon(this.onPageChanged.bind(this, "<"), ArrowLeftIcon, state.currentPage < 1)
+                                }
+                                {this.getPagingBoxes()}
+                                {
+                                    this.renderIcon(this.onPageChanged.bind(this, ">"), ArrowRightIcon, state.totalPages <= (state.currentPage + 1))
+                                }
+                                {
+                                    this.props.showStartEndButtons &&
+                                    this.renderIcon(this.onPageChanged.bind(this, ">>"), ArrowEndRightIcon, state.totalPages <= (state.currentPage + 1))
+                                }
+                            </ul>
                         </div>
-                    }
-                    {
-                        this.props.showPageSizeOptions &&
-                        <div className="dnn-pager-pageSize-box">
-                            {this.getPageSizeDropDown()}
-                        </div>
-                    }
-                </div>
-            </div >;
+                        {this.props.showPageInfo && !this.props.showPageSizeOptions &&
+                            <div className="dnn-pager-options-info-box">
+                                {this.format(this.props.pageInfoText, this.formatCommaSeparate(state.currentPage + 1), this.formatCommaSeparate(state.totalPages))}
+                            </div>
+                        }
+                        {
+                            this.props.showPageSizeOptions &&
+                            <div className="dnn-pager-pageSize-box">
+                                {this.getPageSizeDropDown()}
+                            </div>
+                        }
+                    </div>
+                </div >
+            );
+        } else {
+            return <div />;
+        }
     }
 }
 Pager.propTypes = {


### PR DESCRIPTION
This is a fix for the following warning:

![image](https://user-images.githubusercontent.com/22524011/51314996-db969080-1a59-11e9-800b-f4de070263d9.png)

This error is coming from every place with the Pager (Task Scheduler, Roles, Users...).

The most common reason is that application tries to modify the state for the unmounted component AND/OR for the component that is already mounted but rendered with nothing (like in our case).
To fix it, we just need to make sure Pager returns something while waiting for data, i.e. empty `div`. Once data prepared it will re-draw Pager component with all its structure.

Fixes https://github.com/dnnsoftware/Dnn.React.Common/issues/195