### PR TITLE
Checkbox component: reference error, props is not defined

### DIFF
--- a/src/Checkbox/index.jsx
+++ b/src/Checkbox/index.jsx
@@ -14,7 +14,7 @@ export default class Checkbox extends Component {
     componentDidUpdate(prevProps) {
         if (this.props.value !== prevProps.value) {
             this.setState({
-                checked: props.value
+                checked: this.props.value
             });
         }
     }


### PR DESCRIPTION
This is a fix to the following error:

![image](https://user-images.githubusercontent.com/22524011/51326823-9cc40300-1a78-11e9-89e6-b4e489589173.png)

This was found on Extensions -> Install Extension -> Accept License checkbox