### PR TITLE
Adds Label and Tooltip stories (reproduces issue)

### DIFF
--- a/src/Label/label.stories.js
+++ b/src/Label/label.stories.js
@@ -1,6 +1,7 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import Label from "./index";
+import { ArrowEndRightIcon } from "../SvgIcons";
 
 storiesOf("Label", module).add("simple label", () => 
     <Label label="Test" />
@@ -19,10 +20,12 @@ storiesOf("Label", module).add("with short tooltip", () =>
 storiesOf("Label", module).add("with short tooltip on right", () =>
     <div style={{paddingTop:100,paddingLeft:100}}>
         <Label 
-            label="Some field label:"             
+            label="Some field label:"   
+            labelType="inline"          
             tooltipMessage="This is a required field"
-            tooltipPlace="top"        
-            tooltipStyle={{float:"",display:"inline",position:"relative",top:11}}
+            tooltipPlace="top"     
+            style={{floar:"left"}}   
+            tooltipStyle={{float:"right"}}
         />
     </div>
 );

--- a/src/Label/label.stories.js
+++ b/src/Label/label.stories.js
@@ -23,7 +23,6 @@ storiesOf("Label", module).add("with short tooltip on right", () =>
             labelType="inline"          
             tooltipMessage="This is a required field"
             tooltipPlace="top"     
-            style={{floar:"left"}}   
             tooltipStyle={{float:"right"}}
         />
     </div>

--- a/src/Label/label.stories.js
+++ b/src/Label/label.stories.js
@@ -2,4 +2,66 @@ import React from "react";
 import { storiesOf } from "@storybook/react";
 import Label from "./index";
 
-storiesOf("Label", module).add("with content", () => <Label label="Test" />);
+storiesOf("Label", module).add("simple label", () => 
+    <Label label="Test" />
+);
+
+storiesOf("Label", module).add("with short tooltip", () =>
+    <div style={{paddingTop:100,paddingLeft:100}}>
+        <Label 
+            label="Some field label:" 
+            tooltipMessage="This is a required field"
+            tooltipPlace="top"        
+        />
+    </div>
+);
+
+storiesOf("Label", module).add("with short tooltip on right", () =>
+    <div style={{paddingTop:100,paddingLeft:100}}>
+        <Label 
+            label="Some field label:"             
+            tooltipMessage="This is a required field"
+            tooltipPlace="top"        
+            tooltipStyle={{float:"",display:"inline",position:"relative",top:11}}
+        />
+    </div>
+);
+
+storiesOf("Label", module).add("Reproduces issue", () =>    
+    <div style={{paddingTop:100,paddingLeft:100}}>
+        <p>This case reproduces the issue identified in <br />
+            <a href="https://github.com/dnnsoftware/Dnn.AdminExperience/pull/320">https://github.com/dnnsoftware/Dnn.AdminExperience/pull/320</a><br /> and <br />
+            <a href="https://github.com/romainberger/react-portal-tooltip/issues/84">https://github.com/romainberger/react-portal-tooltip/issues/84</a>
+        </p>
+        <Label 
+            label="Some field label:" 
+            labelType="inline"
+            tooltipMessage={["This is a required field", "it should show as a list", "and be on the bottom right"]}
+            tooltipPlace="top"
+        />
+    </div>
+);
+
+
+
+
+
+// ---------------- Label available props -------------------
+//
+// Label.propTypes = {
+//     label: PropTypes.string,
+//     className: PropTypes.string,
+//     labelFor: PropTypes.string,
+//     tooltipMessage: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+//     tooltipPlace: PropTypes.string,
+//     tooltipStyle: PropTypes.object,
+//     tooltipColor: PropTypes.string,
+//     labelType: PropTypes.oneOf(["inline", "block"]),
+//     style: PropTypes.object,
+//     extra: PropTypes.node,
+//     onClick: PropTypes.func
+// };
+// Label.defaultProps = {
+//     labelType: "block",
+//     className: ""
+// };

--- a/src/Label/label.stories.js
+++ b/src/Label/label.stories.js
@@ -1,7 +1,6 @@
 import React from "react";
 import { storiesOf } from "@storybook/react";
 import Label from "./index";
-import { ArrowEndRightIcon } from "../SvgIcons";
 
 storiesOf("Label", module).add("simple label", () => 
     <Label label="Test" />

--- a/src/Tooltip/style.less
+++ b/src/Tooltip/style.less
@@ -1,5 +1,8 @@
 @import "../../styles/index";
 .dnn-ui-common-tooltip {
+    .icon{
+        display:inline;
+    }
     .tooltip-text {
         z-index: 10000;
         max-width: 255px;

--- a/src/Tooltip/style.less
+++ b/src/Tooltip/style.less
@@ -1,8 +1,5 @@
 @import "../../styles/index";
 .dnn-ui-common-tooltip {
-    .icon{
-        display:inline;
-    }
     .tooltip-text {
         z-index: 10000;
         max-width: 255px;

--- a/src/Tooltip/tooltip.stories.js
+++ b/src/Tooltip/tooltip.stories.js
@@ -1,30 +1,103 @@
-import React from "react";
+import React, { Component } from "react";
 import { storiesOf } from "@storybook/react";
 import Tooltip from "./index";
 
-storiesOf("Tooltip", module).add("with error", () => (
-  <Tooltip
-    type="error"
-    messages={["Tooltip message"]}
-    rendered={true}
-    tooltipPlace="bottom"
-  />
+storiesOf("Tooltip", module).add("error with only required props", () => (
+  <div style={{marginTop:100, marginLeft:100}}>
+    <Tooltip
+      type="error"
+      messages={["Tooltip message"]}
+      tooltipPlace="top"
+    />
+  </div>
 ));
 
-storiesOf("Tooltip", module).add("with warning", () => (
-  <Tooltip
-    type="warning"
-    messages={["Tooltip message"]}
-    rendered={true}
-    tooltipPlace="bottom"
-  />
+storiesOf("Tooltip", module).add("warning list on bottom", () => (
+  <div style={{marginTop:100, marginLeft:100}}>
+    <Tooltip
+      type="warning"
+      messages={["This tooltip message is longer", "and is an array", "with 3 strings","it shows as a list of items"]}
+      tooltipPlace="bottom"
+    />
+  </div>
 ));
 
-storiesOf("Tooltip", module).add("with info", () => (
-  <Tooltip
-    type="info"
-    messages={["Tooltip message"]}
-    rendered={true}
-    tooltipPlace="bottom"
-  />
+storiesOf("Tooltip", module).add("info with long message and maxWidth on bottom", () => (
+  <div style={{marginTop:100, marginLeft:100}}>
+    <Tooltip
+      type="info"
+      messages={["This is a longer message but it should be limited to 50px wide"]}
+      rendered={true}
+      tooltipPlace="bottom"
+      maxWidth={50}
+    />
+  </div>
 ));
+
+storiesOf("Tooltip", module).add("global setting and delayhide", () => (
+  <div style={{marginTop:100, marginLeft:100}}>
+    <Tooltip
+      type="global"
+      messages={["This tooltip should hide just after 3 seconds of leaving it"]}
+      rendered={true}
+      tooltipPlace="top"
+      delayHide={3000}
+    />
+  </div>
+));
+
+storiesOf("Tooltip", module).add("not rendered", () => (
+  <DynamicRenderedTooltip />
+));
+
+class DynamicRenderedTooltip extends Component {
+  constructor(){
+    super();
+    this.state = {rendered: false};
+  }
+
+  handleToggleRender(){
+    this.setState({rendered: !this.state.rendered});
+  }
+
+  render(){
+    return(
+      <div style={{marginTop:100, marginLeft:100}}>
+        <p>This tooltip should not be rendered until you click the button</p>
+        <button onClick={this.handleToggleRender.bind(this)}>Toggle render of the tootip</button>
+        <Tooltip
+          type="global"
+          messages={["This tooltip renders dynamically"]}
+          rendered={this.state.rendered}
+          tooltipPlace="top"
+        />
+      </div>
+    );
+  }
+}
+
+
+//    ---------- TOOLTIP AVAILABLE PROPS ---------------
+//
+// Tooltip.propTypes = {
+//   messages: PropTypes.array.isRequired,
+//   type: PropTypes.oneOf(["error", "warning", "info", "global"]).isRequired,
+//   rendered: PropTypes.bool,
+//   tooltipPlace: PropTypes.oneOf(["top", "bottom"]).isRequired,
+//   style: PropTypes.object,
+//   tooltipStyle: PropTypes.object,
+//   tooltipColor: PropTypes.string,
+//   className: PropTypes.string,
+//   delayHide: PropTypes.number,
+//   customIcon: PropTypes.node,
+//   tooltipClass: PropTypes.string,
+//   onClick: PropTypes.func,
+//   maxWidth: PropTypes.number
+// };
+
+// Tooltip.defaultProps = {
+//   tooltipPlace: "top",
+//   type: "info",
+//   delayHide: 100,
+//   maxWidth: 400
+// };


### PR DESCRIPTION
I wanted to test other tooltip components to resolve our issue with multiple tooltips not working (see issue https://github.com/dnnsoftware/Dnn.AdminExperience/issues/334 ) and wanted to add some stories to test before/after, ends up I found a way to reproduce the issue in the storybook which could make it easier to troubleshoot.

So this PR:
- Adds a couple of use cases of labels and tooltips
- Reproduces the issue that we are having with multiple tooltips
- Should help the owners of react-portal-tooltip resolve the issue maybe before we decide to replace it with another component (see https://github.com/romainberger/react-portal-tooltip/issues/84 ) . If not, well at least it gives us a test bed to try other replacement components to solve this issue.