### PR TITLE
Fixes the FileUpload component that was not loading the image when mounted

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,6 +61,7 @@ module.exports = {
         "import/named": 2,
         "import/default": 2,
         "filenames/match-exported": 2,
-        "react/no-deprecated": "error"
+        "react/no-deprecated": "error",
+        "no-dupe-class-members": "error"
     }
 };

--- a/src/FileUpload/index.jsx
+++ b/src/FileUpload/index.jsx
@@ -63,6 +63,8 @@ export default class FileUpload extends Component {
         if (file) {
             this.updateStateAndReloadImage(file);
         }
+        window.addEventListener("dragover", this.prevent);
+        window.addEventListener("drop", this.prevent);
     }
 
     componentDidUpdate(prevProps) {
@@ -81,11 +83,6 @@ export default class FileUpload extends Component {
         if (props.portalId !== prevProps.portalId) {         
             this.setState({ showFolderPicker: false });
         }
-    }
-
-    componentDidMount() {
-        window.addEventListener("dragover", this.prevent);
-        window.addEventListener("drop", this.prevent);
     }
 
     prevent(e) {

--- a/src/Sortable/index.jsx
+++ b/src/Sortable/index.jsx
@@ -68,6 +68,7 @@ export default class Sortable extends Component {
     setFieldSelected(id, selected) {
         let {items} = this.state;
 
+        // This file uses == intead of === at multiple places, please do not fix until we rewrite this or the sorting will fail
         items.forEach((items) => {
             if (items.id == id) {
                 items.selected = selected;


### PR DESCRIPTION
The FileUpload component should load the existing image when mounted, it had componentDidMount twice in the same class so only half the loading code ran.

This PR:
- Adds an eslint rule to throw an error when there are duplicate class members
- Merges the duplicate class methods in the FileUpload component
- Adds a comment about the build warning which are unavoidable for the moment (we should rewrite that part in 9.4 but just want to prevent people from undoing that workaround until then).

I will go close https://github.com/dnnsoftware/Dnn.AdminExperience/issues/333 and reference this PR since the issue was on the wrong repo.